### PR TITLE
Feat: Chat Page 구현 #14

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -10,7 +10,7 @@ android {
 
     defaultConfig {
         applicationId = "com.example.checkmate"
-        minSdk = 24
+        minSdk = 26
         targetSdk = 34
         versionCode = 1
         versionName = "1.0"

--- a/app/src/main/java/com/provocation/checkmate/ChatFragment.kt
+++ b/app/src/main/java/com/provocation/checkmate/ChatFragment.kt
@@ -41,7 +41,7 @@ class ChatFragment : Fragment() {
             Chat("How are you?", myId, "2024-11-28 10:01:00"),
             Chat("I'm fine, thank you.", mateId),
             Chat("What about you?", mateId),
-        )
+        ) // 해당 부분을 추후 연동하여 가져와야합니다.
 
         chatView = view.findViewById(R.id.chat_view)
         chatView.layoutManager = LinearLayoutManager(requireContext())

--- a/app/src/main/java/com/provocation/checkmate/ChatFragment.kt
+++ b/app/src/main/java/com/provocation/checkmate/ChatFragment.kt
@@ -1,0 +1,66 @@
+package com.provocation.checkmate
+
+import android.os.Bundle
+import android.os.Message
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import android.widget.Button
+import android.widget.EditText
+import android.widget.ScrollView
+import android.widget.Toast
+import androidx.fragment.app.Fragment
+import androidx.recyclerview.widget.LinearLayoutManager
+import androidx.recyclerview.widget.RecyclerView
+import com.provocation.checkmate.model.Chat
+import com.provocation.checkmate.model.ChatAdapter
+
+class ChatFragment : Fragment() {
+
+    private lateinit var chatView: RecyclerView
+    private lateinit var messageEditText: EditText
+    private lateinit var btnSend: Button
+
+    private lateinit var chatList: MutableList<Chat>
+    private lateinit var chatAdapter: ChatAdapter
+
+    override fun onCreateView(
+        inflater: LayoutInflater, container: ViewGroup?,
+        savedInstanceState: Bundle?
+    ): View? {
+        return inflater.inflate(R.layout.fragment_chat, container, false)
+    }
+
+    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+        super.onViewCreated(view, savedInstanceState)
+
+        val myId: Long = 0 // temp
+        val mateId: Long = 1
+        chatList = mutableListOf(
+            Chat("Hello!", myId, "2024-11-28 10:00:00"),
+            Chat("How are you?", myId, "2024-11-28 10:01:00"),
+            Chat("I'm fine, thank you.", mateId),
+            Chat("What about you?", mateId),
+        )
+
+        chatView = view.findViewById(R.id.chat_view)
+        chatView.layoutManager = LinearLayoutManager(requireContext())
+
+        chatAdapter = ChatAdapter(chatList, myId)
+        chatView.adapter = chatAdapter
+        chatView.scrollToPosition(chatList.size - 1)
+
+
+        messageEditText = view.findViewById(R.id.message_input)
+        btnSend = view.findViewById(R.id.btnSend)
+        btnSend.setOnClickListener {
+            val text: String = messageEditText.text.toString()
+            if (text.isNotEmpty()) {
+                chatList.add(Chat(text=text, senderId=myId))
+                chatView.scrollToPosition(chatList.size - 1)
+            }
+            messageEditText.text.clear()
+        }
+    }
+
+}

--- a/app/src/main/java/com/provocation/checkmate/MateDetailInfoFragment.kt
+++ b/app/src/main/java/com/provocation/checkmate/MateDetailInfoFragment.kt
@@ -4,6 +4,7 @@ import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
+import android.widget.Button
 import android.widget.ImageView
 import android.widget.TextView
 import androidx.fragment.app.Fragment
@@ -23,6 +24,8 @@ class MateDetailInfoFragment : Fragment() {
     private lateinit var tvMbti: TextView
     private lateinit var tvHopeIntimacy: TextView
     private lateinit var tvMajor: TextView
+
+    private lateinit var btnStartChat: Button
 
     override fun onCreateView(
         inflater: LayoutInflater, container: ViewGroup?,
@@ -72,5 +75,13 @@ class MateDetailInfoFragment : Fragment() {
 
         tvMajor = view.findViewById(R.id.mate_major)
         tvMajor.text = "컴퓨터공학전공"
+
+        btnStartChat = view.findViewById(R.id.start_chatting)
+        btnStartChat.setOnClickListener {
+            requireActivity().supportFragmentManager.beginTransaction()
+                .replace(R.id.fragment_container, ChatFragment())
+                .addToBackStack(null)
+                .commit()
+        }
     }
 }

--- a/app/src/main/java/com/provocation/checkmate/model/Chat.kt
+++ b/app/src/main/java/com/provocation/checkmate/model/Chat.kt
@@ -1,0 +1,16 @@
+package com.provocation.checkmate.model
+
+import java.time.LocalDateTime
+import java.time.format.DateTimeFormatter
+
+data class Chat(
+    val text: String,
+    val senderId: Long,
+    val date: String
+) {
+    constructor(text: String, senderId: Long) : this(
+        text,
+        senderId,
+        LocalDateTime.now().format(DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss"))
+    )
+}

--- a/app/src/main/java/com/provocation/checkmate/model/ChatAdapter.kt
+++ b/app/src/main/java/com/provocation/checkmate/model/ChatAdapter.kt
@@ -1,0 +1,46 @@
+package com.provocation.checkmate.model
+
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import android.widget.TextView
+import androidx.recyclerview.widget.RecyclerView
+import com.provocation.checkmate.R
+
+class ChatAdapter(private val chatList: List<Chat>, private val myId: Long) :
+    RecyclerView.Adapter<ChatAdapter.ChatViewHolder>() {
+
+    // ViewHolder
+    class ChatViewHolder(itemView: View) : RecyclerView.ViewHolder(itemView) {
+        val tvMessage: TextView = itemView.findViewById(R.id.tvMessage)
+        val tvDate: TextView = itemView.findViewById(R.id.tvDate)
+    }
+
+    // viewType 반환: 0은 내 메시지, 1은 상대 메시지
+    override fun getItemViewType(position: Int): Int {
+        val chat = chatList[position]
+        return if (chat.senderId == myId) {
+            0 // 나의 메시지
+        } else {
+            1 // 상대방의 메시지
+        }
+    }
+
+    override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): ChatViewHolder {
+        val view: View = if (viewType == 0) {
+            LayoutInflater.from(parent.context).inflate(R.layout.my_chat_item, parent, false)
+        } else {
+            LayoutInflater.from(parent.context).inflate(R.layout.other_chat_item, parent, false)
+        }
+        return ChatViewHolder(view)
+    }
+
+    override fun onBindViewHolder(holder: ChatViewHolder, position: Int) {
+        val chat = chatList[position]
+        holder.tvMessage.text = chat.text
+        holder.tvDate.text = chat.date
+    }
+
+    override fun getItemCount(): Int = chatList.size
+}
+

--- a/app/src/main/res/drawable/my_chat_bubble.xml
+++ b/app/src/main/res/drawable/my_chat_bubble.xml
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="utf-8"?>
+<layer-list xmlns:android="http://schemas.android.com/apk/res/android">
+
+    <!-- 말풍선 본체 -->
+    <item>
+        <shape android:shape="rectangle">
+            <solid android:color="#000000" /> <!-- 말풍선 배경색 -->
+            <corners android:radius="12dp" /> <!-- 둥근 모서리 -->
+        </shape>
+    </item>
+
+    <!-- 말풍선 꼬리 -->
+    <item
+        android:gravity="top|start"
+        android:bottom="8dp"
+        android:start="12dp">
+        <shape android:shape="rectangle">
+            <solid android:color="#000000" />
+            <corners android:radius="2dp" /> <!-- 모서리 둥글게 -->
+            <rotation android:fromDegrees="45" /> <!-- 꼬리를 삼각형처럼 보이게 회전 -->
+        </shape>
+    </item>
+</layer-list>

--- a/app/src/main/res/drawable/other_chat_bubble.xml
+++ b/app/src/main/res/drawable/other_chat_bubble.xml
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="utf-8"?>
+<layer-list xmlns:android="http://schemas.android.com/apk/res/android">
+
+    <!-- 말풍선 본체 -->
+    <item>
+        <shape android:shape="rectangle">
+            <solid android:color="#FFFFFF" /> <!-- 말풍선 배경색 -->
+            <corners android:radius="12dp" /> <!-- 둥근 모서리 -->
+        </shape>
+    </item>
+
+    <!-- 말풍선 꼬리 -->
+    <item
+        android:gravity="bottom|end"
+        android:bottom="8dp"
+        android:end="12dp">
+        <shape android:shape="rectangle">
+            <solid android:color="#FFFFFF" />
+            <corners android:radius="2dp" /> <!-- 모서리 둥글게 -->
+            <rotation android:fromDegrees="45" /> <!-- 꼬리를 삼각형처럼 보이게 회전 -->
+        </shape>
+    </item>
+</layer-list>

--- a/app/src/main/res/layout/activity_fragment_manage.xml
+++ b/app/src/main/res/layout/activity_fragment_manage.xml
@@ -9,7 +9,6 @@
             android:id="@+id/main_toolbar"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:orientation="horizontal"
 
             app:layout_constraintBottom_toBottomOf="parent"
             app:layout_constraintStart_toStartOf="parent"
@@ -71,8 +70,7 @@
         android:layout_height="0dp"
         app:layout_constraintTop_toTopOf="parent"
         app:layout_constraintBottom_toTopOf="@id/main_toolbar"
-        app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintHorizontal_bias="0.0"
         app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintVertical_bias="0.0" />
+        app:layout_constraintEnd_toEndOf="parent"
+        />
 </androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/layout/fragment_chat.xml
+++ b/app/src/main/res/layout/fragment_chat.xml
@@ -1,0 +1,77 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:background="#FFD9D9D9"
+    >
+    <LinearLayout
+        android:id="@+id/chat_top"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:background="#00000000"
+        android:orientation="horizontal"
+        android:padding="8dp"
+        app:layout_constraintTop_toTopOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        >
+
+        <android.widget.Button
+            android:id="@+id/btnBack"
+            android:layout_width="50dp"
+            android:layout_height="50dp"
+            android:background="@drawable/ic_arrow_left"
+            android:gravity="center" />
+
+
+        <TextView
+            android:id="@+id/tvTitle"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:layout_weight="1"
+            android:text="user name"
+            android:textColor="@color/black"
+            android:textSize="20sp" />
+    </LinearLayout>
+    
+    <androidx.recyclerview.widget.RecyclerView
+        android:id="@+id/chat_view"
+        android:layout_width="match_parent"
+        android:layout_height="0dp"
+        app:layout_constraintTop_toBottomOf="@+id/chat_top"
+        app:layout_constraintBottom_toTopOf="@id/message_input_layout"
+        />
+
+    <LinearLayout
+        android:id="@+id/message_input_layout"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:orientation="horizontal"
+        android:padding="8dp"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        android:background="@color/white">
+
+        <EditText
+            android:id="@+id/message_input"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:layout_weight="1"
+            android:hint="Type a message"
+            android:inputType="text"
+            android:textColor="@color/black"
+            android:textColorHint="#FFD9D9D9"
+            android:textColorHighlight="#33000000"
+            android:background="@null"/>
+
+        <android.widget.Button
+            android:id="@+id/btnSend"
+            android:layout_width="50dp"
+            android:layout_height="50dp"
+            android:background="@drawable/ic_arrow_left"
+            android:gravity="center" />
+    </LinearLayout>
+
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/layout/my_chat_item.xml
+++ b/app/src/main/res/layout/my_chat_item.xml
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:orientation="horizontal"
+    android:padding="8dp"
+    android:gravity="end">
+
+    <TextView
+        android:id="@+id/tvDate"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginEnd="5dp"
+        android:text="2024.11.18 15:31"
+        android:textColor="@color/black"
+        android:textSize="10sp"
+        android:layout_gravity="bottom"
+        />
+
+    <LinearLayout
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:orientation="horizontal"
+        android:background="@drawable/my_chat_bubble"
+        android:padding="12dp">
+
+        <TextView
+            android:id="@+id/tvMessage"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:text="저랑 룸메 하실래요?"
+            android:textColor="@color/white"
+            android:textSize="16sp"
+            android:lineSpacingExtra="2dp" />
+    </LinearLayout>
+</LinearLayout>

--- a/app/src/main/res/layout/other_chat_item.xml
+++ b/app/src/main/res/layout/other_chat_item.xml
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:orientation="horizontal"
+    android:padding="8dp"
+    android:gravity="start">
+
+    <LinearLayout
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:orientation="horizontal"
+        android:background="@drawable/other_chat_bubble"
+        android:padding="12dp">
+
+        <TextView
+            android:id="@+id/tvMessage"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:text="저랑 룸메 하실래요?"
+            android:textColor="@color/black"
+            android:textSize="16sp"
+            android:lineSpacingExtra="2dp" />
+    </LinearLayout>
+
+    <TextView
+        android:id="@+id/tvDate"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginStart="5dp"
+        android:text="2024.11.18 15:31"
+        android:textColor="@color/black"
+        android:textSize="10sp"
+        android:layout_gravity="bottom"
+        />
+</LinearLayout>


### PR DESCRIPTION
## 🪺 Summary
Chat page를 구현했습니다

## 🌱 Issue Number
<!-- #뒤에 이슈넘버 써주시면 자동으로 이슈페이지 연결이 됩니다!-->
- #14 

## 주요내용
저 스스로 다시 상기하려고 쓰는 얘기지만, MateDetailInfoFragment는 호출시 해당 메이트의 id, ChatFragment의 경우엔 나의 id, 메이트 id 모두 넘겨야 정상 작동하지만, 현재로선 단순히 화면만 만든 상황이긴 합니다.
그래도 최대한 추후에 연동하기 편하도록 ChatFragment는 코드상에서 myId, mateId를 나누어
if 채팅의 발신자 id가 나와 같다면 검은색 챗
else 하얀색 챗
으로 출력되도록 동적으로 구현했습니다.

아래 채팅들은 xml로 일일이 그린 것이 아닌 동적으로 채팅이 생기는 것입니다.

채팅방 시작시, 이전 채팅 불러오기
![KakaoTalk_20241129_151309658](https://github.com/user-attachments/assets/3664a13f-2a04-43df-9b16-711eeaa087c2)

입력창 선택시 입력창과 툴바가 키보드를 따라 위로 올라옴
![KakaoTalk_20241129_151309658_01](https://github.com/user-attachments/assets/0554c62d-bfc6-417e-833f-3456f283225f)

채팅 입력
![KakaoTalk_20241129_151309658_03](https://github.com/user-attachments/assets/e7976f08-cdcc-42b9-9631-5fea0e2df769)

## 🙏 To Reviewers
